### PR TITLE
authentication in pgadmin configured in yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ configs:
         "Servers": {
           "1": {
             "Group": "Servers",
-            "Name": "Semester Project 3",
+            "Name": "postgres",
             "Host": "postgres",
             "Port": 5432,
             "MaintenanceDB": "postgres",


### PR DESCRIPTION
With this updated:

- `PGADMIN_CONFIG_SERVER_MODE=False` disables the pgadmin4 login screen.
- `PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=False` removes the need to enter the master password when the login screen is disabled.
- configure connections with DB

Please run before merging 